### PR TITLE
8253816: Switch to Exec W^X mode after JNI DetachCurrentThread

### DIFF
--- a/src/hotspot/share/prims/jni.cpp
+++ b/src/hotspot/share/prims/jni.cpp
@@ -4106,6 +4106,10 @@ jint JNICALL jni_DetachCurrentThread(JavaVM *vm)  {
   thread->exit(false, JavaThread::jni_detach);
   thread->smr_delete();
 
+  // Go to the execute mode, the initial state of the thread on creation.
+  // Use os interface as the thread is not a java one anymore.
+  os::current_thread_enable_wx(WXExec);
+
   HOTSPOT_JNI_DETACHCURRENTTHREAD_RETURN(JNI_OK);
   return JNI_OK;
 }

--- a/test/hotspot/jtreg/runtime/jni/codegenAttachThread/TestCodegenAttach.java
+++ b/test/hotspot/jtreg/runtime/jni/codegenAttachThread/TestCodegenAttach.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @requires os.arch == "aarch64" & os.family == "mac"
+ * @run main/othervm/native TestCodegenAttach
+ */
+
+public class TestCodegenAttach {
+
+    static native void testCodegenAttach();
+
+    static {
+        System.loadLibrary("codegenAttach");
+    }
+
+    public static void main(String[] args) throws Throwable {
+        testCodegenAttach();
+    }
+}

--- a/test/hotspot/jtreg/runtime/jni/codegenAttachThread/libcodegenAttach.c
+++ b/test/hotspot/jtreg/runtime/jni/codegenAttachThread/libcodegenAttach.c
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+#include <pthread.h>
+#include <string.h>
+
+#include <sys/mman.h>
+
+#include "jni.h"
+
+JavaVM* jvm;
+
+#ifdef __APPLE__
+#define MACOS_ONLY(x) x
+#else // __APPLE__
+#define MACOS_ONLY(x)
+#endif
+
+static void* codegen;
+
+static int thread_start2(int val) {
+  JNIEnv *env;
+  jclass class_id;
+  jmethodID method_id;
+  int res;
+
+  printf("Native thread is running and attaching ...\n");
+
+  res = (*jvm)->AttachCurrentThread(jvm, (void **)&env, NULL);
+  if (res != JNI_OK) {
+    fprintf(stderr, "Test ERROR. Can't attach current thread: %d\n", res);
+    exit(1);
+  }
+
+  res = (*jvm)->DetachCurrentThread(jvm);
+  if (res != JNI_OK) {
+    fprintf(stderr, "Test ERROR. Can't detach current thread: %d\n", res);
+    exit(1);
+  }
+
+  printf("Native thread is about to finish\n");
+  return 1 + val;
+}
+
+static int trampoline(int(*fn)(int), int arg) {
+  int val = fn(arg);
+  // ensure code in MAP_JIT area after target function returns
+  return 1 + val;
+}
+
+static void * thread_start(void* unused) {
+  int val = ((int(*)(int(*)(int),int))codegen)(thread_start2, 10);
+  printf("return val = %d\n", val);
+  return NULL;
+}
+
+JNIEXPORT void JNICALL
+Java_TestCodegenAttach_testCodegenAttach
+(JNIEnv *env, jclass cls) {
+
+  codegen = mmap(NULL, 0x1000,
+      PROT_READ | PROT_WRITE | PROT_EXEC,
+      MAP_PRIVATE | MAP_ANONYMOUS MACOS_ONLY(| MAP_JIT), -1, 0);
+  if (codegen == MAP_FAILED) {
+    perror("mmap");
+    exit(1);
+  }
+
+  MACOS_ONLY(pthread_jit_write_protect_np(false));
+
+  memcpy(codegen, trampoline, 128);
+
+  MACOS_ONLY(pthread_jit_write_protect_np(true));
+
+  pthread_t thread;
+  int res = (*env)->GetJavaVM(env, &jvm);
+  if (res != JNI_OK) {
+    fprintf(stderr, "Test ERROR. Can't extract JavaVM: %d\n", res);
+    exit(1);
+  }
+
+  if ((res = pthread_create(&thread, NULL, thread_start, NULL)) != 0) {
+    fprintf(stderr, "TEST ERROR: pthread_create failed: %s (%d)\n", strerror(res), res);
+    exit(1);
+  }
+
+  if ((res = pthread_join(thread, NULL)) != 0) {
+    fprintf(stderr, "TEST ERROR: pthread_join failed: %s (%d)\n", strerror(res), res);
+    exit(1);
+  }
+}


### PR DESCRIPTION
JVM leaves Writeable mode for W^X after JNI detach thread. #9 describes an example when this breaks application expectations: a thread returns to a code generated by the application after JNI detach and crashes. Since the default mode is Executable, the change to Writeable is implicit and not expected.

The proposed solution is to ensure Executable mode after JNI detach.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8253816](https://bugs.openjdk.java.net/browse/JDK-8253816)

### Issue
 * [JDK-8253816](https://bugs.openjdk.java.net/browse/JDK-8253816): Support macOS W^X ⚠️ Title mismatch between PR and JBS.


### Reviewers
 * [Bernhard Urban-Forster](https://openjdk.java.net/census#burban) (@lewurm - Author) ⚠️ Review applies to 9066cceca103bdb31278d0e83baea6f02bb93428


### Download
`$ git fetch https://git.openjdk.java.net/aarch64-port pull/10/head:pull/10`
`$ git checkout pull/10`
